### PR TITLE
Ensure $(DESTDIR)/bin exists before installing smackage binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ smackage-install:
 	mv ../../../bin/smackage.new ../../../bin/smackage
 
 install:
+	mkdir -p $(DESTDIR)/bin
 	rm -f $(DESTDIR)/bin/smackage.new
 	cp $(BIN)/smackage $(DESTDIR)/bin/smackage.new
 	mv $(DESTDIR)/bin/smackage.new $(DESTDIR)/bin/smackage


### PR DESCRIPTION
Trying to install smackage with a nonexistent DESTDIR via `make install` produces the following error:
```
$ DESTDIR=/home/p/.smackage make install
rm -f /home/p/.smackage/bin/smackage.new
cp bin/smackage /home/p/.smackage/bin/smackage.new
cp: cannot create regular file ‘/home/p/.smackage/bin/smackage.new’: No such file or directory
make: *** [install] Error 1
```
This patch makes sure that the required directory exists before attempting to install files.