### PR TITLE
Improve Makefile portability - do not require pkg-config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ MLTON=mlton
 
 SMLNJ=sml
 
-POLYML=polyml
-POLYML_LDFLAGS = $(shell pkg-config --libs polyml)
+POLYML := $(shell { command -v poly || echo polyml; } 2>/dev/null)
+POLYML_LDFLAGS := $(shell { pkg-config --libs polyml || echo -lpolymain -lpolyml; } 2>/dev/null)
 
 MLKIT=mlkit
 


### PR DESCRIPTION
Gian: this is intended to (i) reduce the dependence on `pkg-config` and (ii) cope with the POLYML executable being either `poly` or `polyml`.

-- Mark